### PR TITLE
Iteration #1 — VPC + S3 Express “Hot Shelf” + Crypto & IAM Baseline

### DIFF
--- a/feature-store/infra/express.tf
+++ b/feature-store/infra/express.tf
@@ -1,0 +1,20 @@
+data "aws_availability_zone" "zone" {
+  name = "ap-south-1a"
+}
+
+locals {
+  az_id       = data.aws_availability_zone.zone.id
+  bucket_name = "flashfeat-hot--${local.az_id}--x-s3"
+}
+
+resource "aws_s3_directory_bucket" "flashfeat_hot" {
+  bucket = local.bucket_name
+  location {
+    name = local.az_id
+  }
+
+  force_destroy   = true
+  data_redundancy = "SingleAvailabilityZone" # This is the default, but explicitly set for clarity
+}
+
+data "aws_caller_identity" "current" {}

--- a/feature-store/infra/iam.tf
+++ b/feature-store/infra/iam.tf
@@ -1,0 +1,47 @@
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "flashfeat_enclave" {
+  name               = "flashfeat-ec2-enclave"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+
+  tags = {
+    project     = "flashfeat"
+    environment = "dev"
+  }
+}
+
+resource "aws_iam_role_policy" "flashfeat_enclave" {
+  role = aws_iam_role.flashfeat_enclave.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = ["s3:GetObject"],
+        Resource = [
+          aws_s3_directory_bucket.flashfeat_hot.arn,
+          "${aws_s3_directory_bucket.flashfeat_hot.arn}/*"
+        ]
+      },
+      {
+        Effect   = "Allow",
+        Action   = ["kms:GenerateDataKey*", "kms:Decrypt"],
+        Resource = aws_kms_key.flashfeat_sse.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "flashfeat_enclave" {
+  name = "flashfeat-ec2-enclave"
+  role = aws_iam_role.flashfeat_enclave.name
+}

--- a/feature-store/infra/kms.tf
+++ b/feature-store/infra/kms.tf
@@ -1,0 +1,40 @@
+resource "aws_kms_key" "flashfeat_sse" {
+  description             = "Flashfeat envelope-encryption key"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowAccountUse",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" },
+        Action    = "kms:*",
+        Resource  = "*"
+      },
+      {
+        Sid       = "DenyCrossAccount",
+        Effect    = "Deny",
+        Principal = "*",
+        Action    = "kms:*",
+        Resource  = "*",
+        Condition = {
+          StringNotEquals = {
+            "aws:PrincipalAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    project     = "flashfeat"
+    environment = "dev"
+  }
+}
+
+resource "aws_kms_alias" "flashfeat_sse" {
+  name          = "alias/flashfeat-sse"
+  target_key_id = aws_kms_key.flashfeat_sse.id
+}

--- a/feature-store/infra/network.tf
+++ b/feature-store/infra/network.tf
@@ -36,3 +36,8 @@ resource "aws_route_table" "flashfeat_dev" {
   tags = merge(aws_vpc.flashfeat_dev.tags, { Name = "flashfeat-dev-rt" })
 
 }
+
+resource "aws_route_table_association" "flashfeat_dev_a" {
+  subnet_id      = aws_subnet.flashfeat_dev_a.id
+  route_table_id = aws_route_table.flashfeat_dev.id
+}

--- a/feature-store/infra/network.tf
+++ b/feature-store/infra/network.tf
@@ -1,0 +1,38 @@
+resource "aws_vpc" "flashfeat_dev" {
+  cidr_block           = "10.10.0.0/24"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name        = "flashfeat-dev"
+    project     = "flashfeat"
+    environment = "dev"
+  }
+}
+
+resource "aws_subnet" "flashfeat_dev_a" {
+  vpc_id                  = aws_vpc.flashfeat_dev.id
+  availability_zone       = "ap-south-1a"
+  cidr_block              = "10.10.0.0/26"
+  map_public_ip_on_launch = true
+  tags = {
+    Name        = "flashfeat-dev-a"
+    project     = "flashfeat"
+    environment = "dev"
+  }
+}
+
+resource "aws_internet_gateway" "flashfeat_dev_igw" {
+  vpc_id = aws_vpc.flashfeat_dev.id
+  tags   = merge(aws_vpc.flashfeat_dev.tags, { Name = "flashfeat-dev-igw" })
+}
+
+resource "aws_route_table" "flashfeat_dev" {
+  vpc_id = aws_vpc.flashfeat_dev.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.flashfeat_dev_igw.id
+  }
+  tags = merge(aws_vpc.flashfeat_dev.tags, { Name = "flashfeat-dev-rt" })
+
+}


### PR DESCRIPTION
# Iteration #1 — VPC + S3 Express “Hot Shelf” + Crypto & IAM Baseline

## 🚀 What this delivers (Day 1 / MVP-Step 1)

| Layer | Resources |
|-------|-----------|
| **Network** | • VPC `10.10.0.0/24` <br>• Public subnet `/26` <br>• Internet Gateway <br>• Public route table + association |
| **Storage** | • S3 Express **directory bucket** `flashfeat-hot` (AES-256 at rest) |
| **Crypto** | • KMS CMK `alias/flashfeat-sse` (rotation on, cross-acct denied) |
| **Compute IAM** | • IAM role + instance-profile `flashfeat-ec2-enclave` <br>• Inline policy: `s3:GetObject` on HOT bucket, `kms:GenerateDataKey* / Decrypt` on CMK |

**Total Terraform resources:** **11 to add**  
*(4 network + 1 bucket + 2 CMK/Alias + 3 IAM + 1 association)*

## ✅ Post-merge apply checklist
- [ ] `terraform apply` in CI (or manual) finishes green.  
- [ ] `aws s3control list-buckets` shows the new bucket.  
- [ ] `aws kms list-aliases | grep flashfeat-sse` returns alias.  
- [ ] `aws ec2 describe-vpcs` lists `flashfeat-dev`.  
- [ ] Instance-profile visible in IAM console.

---

## 🔜 Next up (Iteration #2)
* Launch Template + ASG (`c7g.large`, Nitro Enclave enabled)  
* Security Group (80/443 ingress, vsock local)  
* Sidecar / Enclave Go build in CI  
* `apply` step gated on merges to **main**

> Merging this PR **completes Iteration #1** and unblocks compute-layer work.
